### PR TITLE
Add "or" to highlight @keywords

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -9,7 +9,8 @@
   "in"
   "rec"
   "with" 
-  "assert" 
+  "assert"
+  "or"
 ] @keyword
 
 ((identifier) @variable.builtin


### PR DESCRIPTION
Not really sure about if "or" is considered a keyword theoretically. 
However the current nix-mode in Emacs does display it as such, and hence i thought it was missing here.