### PR TITLE
add unit tests for highlights

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "nan": "^2.14.2"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.20.0"
+    "tree-sitter-cli": "^0.20.6"
   },
   "tree-sitter": [
     {

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -9,7 +9,8 @@
   "in"
   "rec"
   "with" 
-  "assert" 
+  "assert"
+  "or"
 ] @keyword
 
 ((identifier) @variable.builtin

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -74,6 +74,7 @@
   ";"
   "."
   ","
+  "="
 ] @punctuation.delimiter
 
 [

--- a/test/highlight/basic.nix
+++ b/test/highlight/basic.nix
@@ -1,0 +1,80 @@
+{
+  or = { or = 1; }.or or 42;
+  # <- property
+  #  ^ punctuation.delimiter
+  #      ^ property
+  #                 ^ property
+  #                    ^ keyword
+  the-question = if builtins.true then "to be" else "not to be";
+  # <- property
+  #  ^ property
+  #    ^ property
+  #               ^ keyword
+  #                  ^ variable.builtin
+  #                           ^ property
+  #                                ^ keyword
+  #                                      ^ string
+  #                                             ^ keyword
+  #                                                    ^ string
+  null = if null then true else false;
+  # <- property
+  #          ^ variable.builtin
+  #                    ^ variable.builtin
+  #                              ^ variable.builtin
+  pkgs' = { inherit (pkgs) stdenv lib; };
+  # <- property
+  #   ^ property
+  #          ^ keyword
+  #                   ^ variable
+  #                         ^ property
+  #                                ^ property
+  thing' =
+    # <- property
+    let inherit (pkgs) stdenv lib;
+    # <- keyword
+    #    ^ keyword
+    #             ^ variable
+    #                   ^ property
+    #                          ^ property
+    in derivation rec {
+    # <- keyword
+      # ^ function.builtin
+      #            ^ keyword
+      pname = "thing";
+      # <- property
+      #         ^ string
+      version = "v1.2.3";
+      name = "${pname}-${version}";
+      # <- property
+      #      ^ string
+      #       ^ punctuation.special
+      #          ^ variable
+      #              ^ punctuation.special
+      #               ^ string
+      #                   ^ variable
+      #                          ^ string
+      buildInputs = with pkgs; [ thing_a thing_b ];
+      # <- property
+      #              ^ keyword
+      #                   ^ variable
+      #                           ^ variable
+      #                                    ^ variable
+    };
+  assert_bool = bool: assert lib.isBool bool; bool;
+  # <- property
+  #               ^ variable.parameter
+  #                     ^ keyword
+  #                            ^ variable
+  #                                ^ function
+  #                                       ^ variable
+  #                                             ^ variable
+  import = import ./overlays.nix { inherit pkgs; };
+  # <- property
+  #         ^ function.builtin
+  #                 ^ string.special.path
+  #                                 ^ keyword
+  #                                         ^ property
+  uri = https://github.com;
+  #      ^ string.special.uri
+  #                ^ string.special.uri
+}


### PR DESCRIPTION
Builds on #14 to highlight `or` when used as a keyword, plus adds some unit tests for the highlights (see the unit testing docs [here](https://tree-sitter.github.io/tree-sitter/syntax-highlighting#unit-testing))

I also have a maintenance commit here for updating the tree-sitter-cli, but I can drop that out if you prefer.