### PR TITLE
add language injection queries

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,39 @@
+; mark arbitary languages with a comment
+((((comment) @injection.language) .
+  (indented_string_expression (string_fragment) @injection.content))
+  (#set! injection.combined))
+
+((binding
+   attrpath: (attrpath (identifier) @_path)
+   expression: (indented_string_expression
+     (string_fragment) @injection.content))
+ (#match? @_path "(^\\w*Phase|(pre|post)\\w*|(.*\\.)?\\w*([sS]cript|[hH]ook)|(.*\\.)?startup)$")
+ (#set! injection.language "bash")
+ (#set! injection.combined))
+
+((apply_expression
+   function: (apply_expression function: (_) @_func)
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_func "(^|\\.)writeShellScript(Bin)?$")
+ (#set! injection.language "bash")
+ (#set! injection.combined))
+
+(apply_expression
+  (apply_expression
+    function: (apply_expression
+      function: ((_) @_func)))
+    argument: (indented_string_expression (string_fragment) @injection.content)
+  (#match? @_func "(^|\\.)runCommand(((No)?(CC))?(Local)?)?$")
+  (#set! injection.language "bash")
+  (#set! injection.combined))
+
+(apply_expression
+  function: ((_) @_func)
+  argument: (_ (_)* (_ (_)* (binding
+    attrpath: (attrpath (identifier) @_path)
+     expression: (indented_string_expression
+       (string_fragment) @injection.content))))
+  (#match? @_func "(^|\\.)writeShellApplication$")
+  (#match? @_path "^text$")
+  (#set! injection.language "bash")
+  (#set! injection.combined))


### PR DESCRIPTION
resolves #13

Only tested in helix-editor/helix#3594 atm, but the queries should be generic enough to work everywhere.

~~There is an [issue](https://github.com/helix-editor/helix/pull/3594#issuecomment-1232472905) with bash injection where a regex of `/".*/` isn't detected by bash's tree-sitter just before a `${` interpolation.
This causes the quoting to become unbalanced, since it doesn't detect the opening quote, it reads the rest of the string as a qouted bash string incorrectly. I haven't quite gotten to the bottom of it, but I'm fairly confident its an issue in tree-sitter-bash, since this doesn't happen in python or other language injections I tried.~~ solved with `injection.combined`.

Only outstanding issue is #32, which is solved by #33