### PR TITLE
queries: filename-based language injection for indented strings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,8 @@
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib;
 
+        filenameInjections = import ./queries/filename-injections.nix { inherit pkgs lib; };
+
       in
       {
         checks =
@@ -48,6 +50,7 @@
             generated-diff = mkCheck "generated-diff" ''
               HOME=. npm run generate
               diff -r src/ ${self}/src
+              diff queries/ ${self}/queries
             '';
 
             treefmt = mkCheck "treefmt" "treefmt --no-cache --fail-on-change";
@@ -98,6 +101,7 @@
 
         packages.tree-sitter-nix = pkgs.callPackage ./default.nix { src = self; };
         packages.default = self.packages.${system}.tree-sitter-nix;
+        packages.generate-filename-injections = filenameInjections.generate;
         devShells.default = pkgs.callPackage ./shell.nix { };
 
         formatter = pkgs.writeShellScriptBin "tree-sitter-nix-fmt" ''

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run generate && node-gyp build",
     "build-wasm": "tree-sitter build-wasm",
-    "generate": "tree-sitter generate --abi 13",
+    "generate": "tree-sitter generate --abi 13 && nix run .#generate-filename-injections",
     "prepublishOnly": "npm run build && npm run build-wasm",
     "test": "tree-sitter test"
   },

--- a/queries/filename-injections.nix
+++ b/queries/filename-injections.nix
@@ -1,0 +1,81 @@
+# Filename-based language injection rules for nix indented strings.
+#
+# Detects the language of an indented string argument based on the file
+# extension of a preceding filename argument in curried function calls:
+#
+#   pkgs.writeText "style.css" ''
+#     body { margin: 0; }
+#   ''
+#
+# To add a new language, append an entry to the list below.
+# Then run: nix run .#generate-filename-injections
+# Or: npm run generate
+
+{ pkgs, lib }:
+
+let
+  languages = [
+    { ext = "html|htm"; lang = "html"; }
+    { ext = "css";      lang = "css"; }
+    { ext = "js";       lang = "javascript"; }
+    { ext = "ts";       lang = "typescript"; }
+    { ext = "json";     lang = "json"; }
+    { ext = "yml|yaml"; lang = "yaml"; }
+    { ext = "toml";     lang = "toml"; }
+    { ext = "py";       lang = "python"; }
+    { ext = "lua";      lang = "lua"; }
+    { ext = "nix";      lang = "nix"; }
+  ];
+
+  rules = pkgs.writeText "filename-injections.scm"
+    (lib.concatMapStrings ({ ext, lang }: ''
+
+      ((apply_expression
+         function: (apply_expression
+           argument: (string_expression (string_fragment) @_filename))
+         argument: (indented_string_expression (string_fragment) @injection.content))
+       (#match? @_filename "\\.(${ext})$")
+       (#set! injection.language "${lang}")
+       (#set! injection.combined))
+    '') languages);
+
+  # Script that splices the generated rules into queries/injections.scm.
+  # Idempotent: replaces between @generated-start/@generated-end markers,
+  # or appends if no markers exist.
+  generate = pkgs.writeShellScriptBin "generate-filename-injections" ''
+    set -euo pipefail
+    FILE=queries/injections.scm
+    BLOCK=$(${pkgs.coreutils}/bin/mktemp)
+    trap 'rm -f "$BLOCK"' EXIT
+
+    {
+      echo '; @generated-start filename-injections'
+      echo '; Filename-based injection: detect language from file extension in'
+      echo '; curried calls like writeText "file.html" content.'
+      echo '; Source of truth: queries/filename-injections.nix'
+      echo '; Regenerate with: nix run .#generate-filename-injections'
+      cat ${rules}
+      echo '; @generated-end filename-injections'
+    } > "$BLOCK"
+
+    if ${pkgs.gnugrep}/bin/grep -q '@generated-start filename-injections' "$FILE"; then
+      ${pkgs.gawk}/bin/awk -v blockfile="$BLOCK" '
+        /@generated-start filename-injections/ {
+          while ((getline line < blockfile) > 0) print line
+          close(blockfile)
+          skip = 1
+          next
+        }
+        /@generated-end filename-injections/ { skip = 0; next }
+        !skip { print }
+      ' "$FILE" > "''${FILE}.tmp"
+      mv "''${FILE}.tmp" "$FILE"
+    else
+      printf '\n' >> "$FILE"
+      cat "$BLOCK" >> "$FILE"
+    fi
+  '';
+
+in {
+  inherit languages rules generate;
+}

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -37,3 +37,90 @@
   (#match? @_path "^text$")
   (#set! injection.language "bash")
   (#set! injection.combined))
+
+; @generated-start filename-injections
+; Filename-based injection: detect language from file extension in
+; curried calls like writeText "file.html" content.
+; Source of truth: queries/filename-injections.nix
+; Regenerate with: nix run .#generate-filename-injections
+
+((apply_expression
+   function: (apply_expression
+     argument: (string_expression (string_fragment) @_filename))
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_filename "\\.(html|htm)$")
+ (#set! injection.language "html")
+ (#set! injection.combined))
+
+((apply_expression
+   function: (apply_expression
+     argument: (string_expression (string_fragment) @_filename))
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_filename "\\.(css)$")
+ (#set! injection.language "css")
+ (#set! injection.combined))
+
+((apply_expression
+   function: (apply_expression
+     argument: (string_expression (string_fragment) @_filename))
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_filename "\\.(js)$")
+ (#set! injection.language "javascript")
+ (#set! injection.combined))
+
+((apply_expression
+   function: (apply_expression
+     argument: (string_expression (string_fragment) @_filename))
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_filename "\\.(ts)$")
+ (#set! injection.language "typescript")
+ (#set! injection.combined))
+
+((apply_expression
+   function: (apply_expression
+     argument: (string_expression (string_fragment) @_filename))
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_filename "\\.(json)$")
+ (#set! injection.language "json")
+ (#set! injection.combined))
+
+((apply_expression
+   function: (apply_expression
+     argument: (string_expression (string_fragment) @_filename))
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_filename "\\.(yml|yaml)$")
+ (#set! injection.language "yaml")
+ (#set! injection.combined))
+
+((apply_expression
+   function: (apply_expression
+     argument: (string_expression (string_fragment) @_filename))
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_filename "\\.(toml)$")
+ (#set! injection.language "toml")
+ (#set! injection.combined))
+
+((apply_expression
+   function: (apply_expression
+     argument: (string_expression (string_fragment) @_filename))
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_filename "\\.(py)$")
+ (#set! injection.language "python")
+ (#set! injection.combined))
+
+((apply_expression
+   function: (apply_expression
+     argument: (string_expression (string_fragment) @_filename))
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_filename "\\.(lua)$")
+ (#set! injection.language "lua")
+ (#set! injection.combined))
+
+((apply_expression
+   function: (apply_expression
+     argument: (string_expression (string_fragment) @_filename))
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_filename "\\.(nix)$")
+ (#set! injection.language "nix")
+ (#set! injection.combined))
+; @generated-end filename-injections


### PR DESCRIPTION
## Summary

Detect the language of indented string content based on the file extension of a preceding filename argument in curried function calls:

```nix
pkgs.writeText "index.html" ''
  <div>Hello</div>
''

pkgs.writeTextDir "style.css" ''
  body { margin: 0; }
''
```

This matches any curried call where the penultimate argument is a string with a recognized file extension and the last argument is an indented string. The pattern is function-name agnostic — it works with `writeText`, `writeTextDir`, `builtins.toFile`, or any user-defined function that follows the `func "filename" ''content''` convention.

## Motivation

The existing injection rules detect bash via function names (`writeShellScript`) and attribute names (`*Phase`, `*Hook`). This works well for bash, but other languages embedded in nix strings — HTML, CSS, JSON, Python, etc. — have no detection mechanism beyond the comment hint (`# html`).

File extensions are a universal, unambiguous convention. Unlike attribute names (where `testScript` [could be Perl or Python](https://github.com/nix-community/tree-sitter-nix/pull/55#issuecomment-2269072459)), `.html` is always HTML.

## Implementation

`queries/filename-injections.nix` is the single source of truth — it contains the language list and the generation/splicing logic:

```nix
# To add a new language, append an entry:
{ ext = "html|htm"; lang = "html"; }
```

The generation is fully nix-native:

- **`nix run .#generate-filename-injections`** — regenerates the rules in `injections.scm` (idempotent, replaces between `@generated-start`/`@generated-end` markers)
- **`npm run generate`** — calls the above as part of the standard generate workflow
- **`generated-diff` CI check** — runs the generator and verifies no drift

The rules are checked into `injections.scm` so non-nix consumers (nvim-treesitter, Helix, Emacs, etc.) work without any build step.

Initial languages: HTML, CSS, JavaScript, TypeScript, JSON, YAML, TOML, Python, Lua, Nix.

## Query pattern

```scheme
((apply_expression
   function: (apply_expression
     argument: (string_expression (string_fragment) @_filename))
   argument: (indented_string_expression (string_fragment) @injection.content))
 (#match? @_filename "\\.(html|htm)$")
 (#set! injection.language "html")
 (#set! injection.combined))
```

This matches the AST structure of curried nix function application:

```
(apply_expression                          ; func "file.html" ''content''
  function: (apply_expression              ; func "file.html"
    argument: (string_expression           ; "file.html"
      (string_fragment)))
  argument: (indented_string_expression    ; ''content''
    (string_fragment)))
```

## Test plan

- Tested with `tree-sitter highlight --html` on nix files containing `writeText`, `writeTextDir`, and custom functions with filename arguments
- Verified idempotency: running the generator twice produces identical output
- Verified clean-slate generation: removing all markers and running the generator correctly appends the block

## Related issues

- #54 — Python injection for `testScript` (this PR covers `.py` extension detection)
- #165 — nix injection for `literalExpression` (covered if used as `writeText "foo.nix" ''...''`)
- Complementary to #166 — comment-based injection handles ambiguous cases; filename-based handles the unambiguous ones