### PR TITLE
ci: use supported x86_64-darwin runner

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
         # Inherit GHA actions matrix from a subset of platforms supported by hosted runners
         platforms = {
           "x86_64-linux" = "nscloud-ubuntu-22.04-amd64-4x16";
-          "x86_64-darwin" = "macos-13";
+          "x86_64-darwin" = "macos-15-intel";
           "aarch64-darwin" = "macos-latest";
           "aarch64-linux" = "nscloud-ubuntu-22.04-arm64-4x16";
         };


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

This should be replaced by aarch64-darwin at some point, but this is the minimal change to get CI working.